### PR TITLE
Add CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+www.portolabs.org


### PR DESCRIPTION
It seems the CNAME file is needed. Otherwise https://www.portolabs.org returns 404.