### PR TITLE
Add initial README with project setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# PortoLabsOrg Website
+
+This repository contains the source code for the PortoLabsOrg website, built using Jekyll.
+
+## Purpose
+
+At PortoLabs, we develop AI you can run and trust. Our focus is on responsible, self-hosted solutions that keep data sovereign and projects fully in your control — whether you're an independent organization or an AI enthusiast.
+
+## Prerequisites and Running the Website
+
+To set up and run the project, follow these steps:
+
+1. Ensure the following tools are installed:
+   - **Ruby**: Ruby is required for this project.
+   - **Bundler and Jekyll**: Install both with:
+     ```bash
+     gem install bundler jekyll
+     ```
+
+2. Install dependencies:
+   ```bash
+   bundle install
+   ```
+
+3. Serve the website locally:
+   ```bash
+   bundle exec jekyll serve
+   Server address: http://127.0.0.1:4000/
+   ```


### PR DESCRIPTION
Introduce a README file that outlines the project details, purpose, and instructions for setting up and running the PortoLabsOrg website.